### PR TITLE
Feature/upgrade wizard refactor

### DIFF
--- a/docs/UpgradeWizardRefactorPlan.md
+++ b/docs/UpgradeWizardRefactorPlan.md
@@ -1,0 +1,219 @@
+# Upgrade Wizard Refactor Plan
+
+## Problem Statement
+
+The current upgrade wizard **forces** the user into a blocking wizard flow when the GitHub `SQLVersion` file version is higher than the local `CurrentVersion` constant. This is incorrect because:
+
+1. Changing the GitHub `SQLVersion` file immediately blocks all users on startup.
+2. Users cannot dismiss the wizard — they are locked out of the dashboard.
+3. The upgrade should only run when the **local code version** has been updated (i.e., user pulled new code), not simply because GitHub says a new version exists.
+
+## Current vs. Desired Behavior
+
+| Aspect | Current (Broken) | Desired |
+|---|---|---|
+| GitHub version > Code version | **Blocks** user with upgrade wizard | Shows a **dismissible banner** on the dashboard |
+| User pulls new code | No special handling | Code version updates; if code > DB, upgrade wizard triggers |
+| What triggers DB migration | GitHub version mismatch | **Code version > DB version** mismatch |
+| User can skip banner | No (forced wizard) | Yes (banner is informational only) |
+| DB version tracking | Not tracked in DB | Stored in a `SystemSettings` or `__SchemaVersion` table |
+
+## Architecture Overview
+
+```mermaid
+graph TD
+    A[App Starts] --> B{Can connect to DB?}
+    B -- No --> C[Install Wizard]
+    B -- Yes --> D{Tables exist?}
+    D -- No --> E[Run Initial Scripts]
+    D -- Yes --> F{Admin exists?}
+    F -- No --> G[Create Admin Wizard]
+    F -- Yes --> H{Code Version > DB Version?}
+    H -- Yes --> I[Upgrade Wizard - Run Migration Scripts]
+    H -- No --> J[Dashboard]
+    J --> K{GitHub Version > Code Version?}
+    K -- Yes --> L[Show Update Available Banner]
+    K -- No --> M[No Banner]
+```
+
+## Three Version Concepts
+
+```mermaid
+graph LR
+    subgraph GitHub["GitHub Repository"]
+        GV["SQLVersion file<br/><b>e.g. 2.0</b><br/>Indicates new release exists"]
+    end
+    subgraph LocalCode["Deployed Application Code"]
+        CV["CurrentVersion constant<br/><b>e.g. 1.0</b><br/>Compiled into the binary"]
+    end
+    subgraph Database["SQL Database"]
+        DV["SchemaVersion row<br/><b>e.g. 1.0</b><br/>Tracks applied migrations"]
+    end
+
+    GV -->|"Tells user to update code"| CV
+    CV -->|"Drives DB migration scripts"| DV
+
+    style GV fill:#fff3cd,stroke:#ffc107
+    style CV fill:#d1ecf1,stroke:#0dcaf0
+    style DV fill:#d4edda,stroke:#198754
+```
+
+| Version | Where it lives | Purpose |
+|---|---|---|
+| **GitHub Version** | `SQLVersion` file in GitHub repo | Advertise that a new release is available |
+| **Code Version** | `CurrentVersion` constant in `Home.razor` | The version compiled into the running application |
+| **DB Version** | `SystemSettings` table in SQL | The schema version currently applied to the database |
+
+## Detailed Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Home as Home.razor
+    participant DB as Database
+    participant GH as GitHub
+
+    User->>Home: Navigate to /
+    Home->>DB: CanConnect?
+    DB-->>Home: Yes
+    Home->>DB: Tables exist?
+    DB-->>Home: Yes
+    Home->>DB: Admin exists?
+    DB-->>Home: Yes
+    Home->>DB: Get DB SchemaVersion
+    DB-->>Home: "1.0"
+    
+    alt Code Version > DB Version
+        Home->>User: Show Upgrade Wizard (blocking)
+        User->>Home: Authorize & run migration
+        Home->>DB: Execute scripts from DB version to Code version
+        DB-->>Home: Done
+        Home->>DB: Update SchemaVersion to Code Version
+    else Code Version == DB Version
+        Home->>User: Show Dashboard
+    end
+
+    Home->>GH: Fetch SQLVersion (background)
+    GH-->>Home: "2.0"
+    
+    alt GitHub Version > Code Version
+        Home->>User: Show dismissible banner "Update available"
+    end
+```
+
+## Implementation Steps
+
+### Step 1: Add DB Schema Version Tracking
+
+Add a `SchemaVersion` row to the existing `SystemSettings` table (or create a dedicated table if `SystemSettings` doesn't exist).
+
+```sql
+-- Add to initial install script or as a migration
+IF NOT EXISTS (SELECT 1 FROM SystemSettings WHERE [Key] = 'SchemaVersion')
+    INSERT INTO SystemSettings ([Key], [Value]) VALUES ('SchemaVersion', '1.0');
+```
+
+The DB version is read at startup and compared against `CurrentVersion`.
+
+### Step 2: Refactor `IsDatabaseNeedUpgradeAsync()`
+
+**Current logic (wrong):**
+```
+if (GitHub Version > Code Version) → force upgrade wizard
+```
+
+**New logic:**
+```
+DB Version = read from SystemSettings
+if (Code Version > DB Version) → show upgrade wizard (blocking, runs scripts)
+```
+
+### Step 3: Add Background GitHub Version Check
+
+After the dashboard loads, check GitHub version in the background:
+
+```
+GitHub Version = fetch from GitHub
+if (GitHub Version > Code Version) → set ShowUpdateBanner = true
+```
+
+This is **non-blocking** — the user sees the dashboard with an informational banner.
+
+### Step 4: Add Dismissible Banner Component
+
+A banner at the top of the dashboard:
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ ⬆ Update Available: Version 2.0 is available on GitHub.     │
+│   Pull the latest code to upgrade.                    [ ✕ ] │
+└──────────────────────────────────────────────────────────────┘
+```
+
+- Dismissible (stores state in session so it doesn't reappear until next session)
+- Shows GitHub version and current code version
+- Links to release notes or repo if applicable
+
+### Step 5: Refactor Upgrade Workflow to Be Script-Driven
+
+The `UpgradeWorkflow.razor` should:
+
+1. Determine which scripts to run based on `DB Version → Code Version` gap
+2. Look for SQL files in `!SQL/` named by version (e.g., `01.00.00.sql`, `02.00.00.sql`)
+3. Execute scripts sequentially in version order
+4. Update `SchemaVersion` in the DB after each script succeeds
+
+```mermaid
+flowchart TD
+    A[Start Upgrade] --> B[Read DB SchemaVersion]
+    B --> C[List SQL scripts in !SQL/ folder]
+    C --> D[Filter scripts where version > DB Version AND version <= Code Version]
+    D --> E{Scripts to run?}
+    E -- Yes --> F[Execute next script]
+    F --> G[Update SchemaVersion in DB]
+    G --> E
+    E -- No --> H[Upgrade Complete]
+```
+
+## File Changes Summary
+
+| File | Change |
+|---|---|
+| `Home.razor` | Split version check: DB version for upgrade wizard, GitHub version for banner |
+| `Home.razor` | Add `ShowUpdateBanner` state and dismissible banner markup |
+| `Home.razor` | Rename `IsDatabaseNeedUpgradeAsync()` to check Code vs DB version |
+| `Home.razor` | Add `CheckForGitHubUpdate()` method (non-blocking, runs after dashboard loads) |
+| `UpgradeWorkflow.razor` | Accept `DatabaseVersion` parameter instead of `LatestGitHubVersion` |
+| `UpgradeWorkflow.razor` | Implement real script execution based on version gap |
+| `DatabaseInitializer.cs` | After initial install, write `SchemaVersion = CurrentVersion` to DB |
+| `!SQL/` folder | Future upgrade scripts named by version (e.g., `02.00.00.sql`) |
+
+## State Diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> Checking: App starts
+    Checking --> InstallWizard: No DB / No tables
+    Checking --> CreateAdmin: No admin user
+    Checking --> UpgradeWizard: Code Version > DB Version
+    Checking --> Dashboard: Code Version == DB Version
+
+    Dashboard --> BannerShown: GitHub Version > Code Version
+    Dashboard --> NoBanner: GitHub Version <= Code Version
+
+    UpgradeWizard --> Dashboard: Scripts applied successfully
+    InstallWizard --> Checking: Install complete
+    CreateAdmin --> Checking: Admin created
+
+    BannerShown --> BannerDismissed: User clicks dismiss
+    BannerShown --> BannerShown: User ignores
+    BannerDismissed --> NoBanner: Session state
+```
+
+## Key Principles
+
+1. **GitHub version is advisory only** — it tells the user "a new release exists, go pull the code."
+2. **Code version drives migrations** — the compiled `CurrentVersion` constant determines what DB schema is expected.
+3. **DB version is the source of truth** — the `SchemaVersion` in the database tells us what migrations have already been applied.
+4. **Never block the user for an advisory notification** — the update-available banner is always dismissible.
+5. **The upgrade wizard only appears when the code demands it** — i.e., the user has pulled new code that requires DB changes.

--- a/src/BlazorOrchestrator.Web/Components/Pages/Home.razor
+++ b/src/BlazorOrchestrator.Web/Components/Pages/Home.razor
@@ -23,6 +23,7 @@
 @inject NavigationManager NavigationManager
 @inject JobManager JobManager
 @inject TimeDisplayService TimeDisplayService
+@inject BlazorDataOrchestrator.Core.Services.SettingsService SettingsService
 
 <PageTitle>@(IsInstalling ? "Setup Wizard" : "Dashboard")</PageTitle>
 
@@ -60,7 +61,7 @@ else if (IsInstalling)
     }
     else if (WizardMode == "UPGRADE")
     {
-        <UpgradeWorkflow CurrentCodeVersion="@CurrentVersion" LatestGitHubVersion="@GitHubVersion" OnUpgradeComplete="OnUpgradeComplete" />
+        <UpgradeWorkflow CurrentCodeVersion="@CurrentVersion" DatabaseVersion="@DatabaseVersion" OnUpgradeComplete="OnUpgradeComplete" />
     }
     else
     {
@@ -75,6 +76,20 @@ else if (IsInstalling)
 else
 {
     <RadzenStack Gap="1.5rem" Style="padding: 0.5rem;">
+        @* Update available banner (non-blocking, dismissible) *@
+        @if (ShowUpdateBanner && !BannerDismissed)
+        {
+            <RadzenAlert AlertStyle="AlertStyle.Warning" ShowIcon="true" Variant="Variant.Flat" Shade="Shade.Lighter" AllowClose="true" Close="@DismissUpdateBanner"
+                         Style="margin: 0;">
+                <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="0.5rem" JustifyContent="JustifyContent.SpaceBetween">
+                    <RadzenText TextStyle="TextStyle.Body2" Style="margin: 0;">
+                        <strong>Update Available:</strong> Version <strong>@GitHubVersion</strong> is available (you are on <strong>@CurrentVersion</strong>).
+                        Pull the latest code from GitHub to upgrade.
+                    </RadzenText>
+                </RadzenStack>
+            </RadzenAlert>
+        }
+
         @* Header row with title + action buttons *@
         <RadzenStack Orientation="Orientation.Horizontal" JustifyContent="JustifyContent.SpaceBetween" AlignItems="AlignItems.Start" Wrap="FlexWrap.Wrap" Gap="1rem">
             <RadzenStack Gap="0.25rem">
@@ -243,6 +258,9 @@ else
     private string WizardMode { get; set; } = "";
     private string ErrorMessage { get; set; } = "";
     private string GitHubVersion { get; set; } = "";
+    private string DatabaseVersion { get; set; } = "";
+    private bool ShowUpdateBanner { get; set; }
+    private bool BannerDismissed { get; set; }
 
     private List<JobViewModel> Jobs { get; set; } = new();
     private List<JobViewModel> AllJobs { get; set; } = new();
@@ -273,10 +291,11 @@ else
                 }
             }
 
-            // Load dashboard data in the background so the UI becomes interactive immediately
+            // Load dashboard data and check for GitHub updates in the background
             _ = InvokeAsync(async () =>
             {
                 await LoadDashboardData();
+                await CheckForGitHubUpdateAsync();
                 StateHasChanged();
             });
         }
@@ -347,10 +366,10 @@ else
             return;
         }
 
-        // Check if upgrade is needed
+        // Check if code version is ahead of DB version (needs migration)
         try
         {
-            if (await IsDatabaseNeedUpgradeAsync())
+            if (await IsCodeAheadOfDatabaseAsync())
             {
                 WizardMode = "UPGRADE";
                 IsInstalling = true;
@@ -361,8 +380,8 @@ else
         catch (Exception ex)
         {
             ErrorMessage = $"Version check error: {ex.Message}";
-            WizardMode = "UPGRADE";
-            IsInstalling = true;
+            // On error reading DB version, don't block — continue to dashboard
+            IsInstalling = false;
             IsLoading = false;
             return;
         }
@@ -425,31 +444,59 @@ else
         }
     }
 
-    private async Task<bool> IsDatabaseNeedUpgradeAsync()
+    /// <summary>
+    /// Checks if the compiled code version is ahead of the database schema version.
+    /// If so, migration scripts need to run (blocking upgrade wizard).
+    /// </summary>
+    private async Task<bool> IsCodeAheadOfDatabaseAsync()
     {
         try
         {
-            // Fetch the latest version from GitHub
-            using var httpClient = new HttpClient();
-            httpClient.Timeout = TimeSpan.FromSeconds(10);
-            GitHubVersion = (await httpClient.GetStringAsync(GitHubVersionUrl)).Trim();
+            DatabaseVersion = await SettingsService.GetOrDefaultAsync("SchemaVersion", CurrentVersion);
 
-            // Compare versions - if GitHub version is higher than local code version, upgrade needed
-            // This means there are new SQL scripts to run from CurrentVersion to GitHubVersion
-            if (ConvertVersionToInteger(GitHubVersion) > ConvertVersionToInteger(CurrentVersion))
+            if (ConvertVersionToInteger(CurrentVersion) > ConvertVersionToInteger(DatabaseVersion))
             {
                 return true;
             }
 
-            // Versions match - no upgrade needed, show dashboard (Happy Path!)
             return false;
         }
         catch
         {
-            // If we can't reach GitHub, assume no upgrade needed and continue to dashboard
-            GitHubVersion = CurrentVersion;
+            // If we can't read the DB version, assume it matches code version
+            DatabaseVersion = CurrentVersion;
             return false;
         }
+    }
+
+    /// <summary>
+    /// Non-blocking background check: fetches the GitHub version to show an advisory banner.
+    /// This does NOT trigger the upgrade wizard.
+    /// </summary>
+    private async Task CheckForGitHubUpdateAsync()
+    {
+        try
+        {
+            using var httpClient = new HttpClient();
+            httpClient.Timeout = TimeSpan.FromSeconds(10);
+            GitHubVersion = (await httpClient.GetStringAsync(GitHubVersionUrl)).Trim();
+
+            if (ConvertVersionToInteger(GitHubVersion) > ConvertVersionToInteger(CurrentVersion))
+            {
+                ShowUpdateBanner = true;
+            }
+        }
+        catch
+        {
+            // Can't reach GitHub — no banner
+            GitHubVersion = CurrentVersion;
+        }
+    }
+
+    private void DismissUpdateBanner()
+    {
+        BannerDismissed = true;
+        ShowUpdateBanner = false;
     }
 
     /// <summary>
@@ -506,6 +553,7 @@ else
             _ = InvokeAsync(async () =>
             {
                 await LoadDashboardData();
+                await CheckForGitHubUpdateAsync();
                 StateHasChanged();
             });
         }
@@ -536,6 +584,7 @@ else
             _ = InvokeAsync(async () =>
             {
                 await LoadDashboardData();
+                await CheckForGitHubUpdateAsync();
                 StateHasChanged();
             });
         }

--- a/src/BlazorOrchestrator.Web/Components/Pages/InstallUpgrade/InstallWizard.razor
+++ b/src/BlazorOrchestrator.Web/Components/Pages/InstallUpgrade/InstallWizard.razor
@@ -1,11 +1,13 @@
 @using BlazorOrchestrator.Web.Data
 @using BlazorOrchestrator.Web.Data.Data
 @using BlazorOrchestrator.Web.Services
+@using BlazorDataOrchestrator.Core.Services
 @using Microsoft.EntityFrameworkCore
 @using Microsoft.AspNetCore.Identity
 @inject WizardStateService WizardState
 @inject IServiceProvider ServiceProvider
 @inject IConfiguration Configuration
+@inject SettingsService SettingsService
 
 <RadzenDialog />
 <RadzenNotification />
@@ -259,7 +261,7 @@
                     await DatabaseInitializer.EnsureDatabaseAsync(Configuration, logger, (msg) =>
                     {
                         AddLog(msg);
-                    });
+                    }, SettingsService, "1.0");
                 }
                 catch (Exception ex)
                 {

--- a/src/BlazorOrchestrator.Web/Components/Pages/InstallUpgrade/UpgradeWorkflow.razor
+++ b/src/BlazorOrchestrator.Web/Components/Pages/InstallUpgrade/UpgradeWorkflow.razor
@@ -1,25 +1,27 @@
 @using BlazorOrchestrator.Web.Data
 @using BlazorOrchestrator.Web.Services
+@using BlazorDataOrchestrator.Core.Services
+@using Microsoft.Data.SqlClient
+@using Dapper
 @inject WizardStateService WizardState
+@inject IConfiguration Configuration
+@inject SettingsService SettingsService
 
 @code {
     [Parameter]
     public EventCallback OnUpgradeComplete { get; set; }
 
     [Parameter]
-    public string CurrentCodeVersion { get; set; } = "01.00.00";
+    public string CurrentCodeVersion { get; set; } = "1.0";
 
     [Parameter]
-    public string LatestGitHubVersion { get; set; } = "01.00.00";
+    public string DatabaseVersion { get; set; } = "1.0";
 
     public string Stage { get; set; } = "login";
     public List<string> Logs = new();
     public string Username { get; set; } = string.Empty;
     public string Password { get; set; } = string.Empty;
     public string ErrorMessage { get; set; } = string.Empty;
-    
-    // Check if local version is ahead of GitHub (shouldn't happen in normal scenarios)
-    private bool IsDowngrade => ConvertVersionToInteger(CurrentCodeVersion) > ConvertVersionToInteger(LatestGitHubVersion);
 
     protected override void OnInitialized()
     {
@@ -42,6 +44,52 @@
         return versionNumber;
     }
 
+    /// <summary>
+    /// Converts a version string like "1.0" to the SQL script filename format "01.00.00".
+    /// </summary>
+    private string VersionToScriptPrefix(string version)
+    {
+        var segments = version.Split('.');
+        var parts = new List<string>();
+        for (int i = 0; i < 3; i++)
+        {
+            if (i < segments.Length && int.TryParse(segments[i], out int val))
+                parts.Add(val.ToString("D2"));
+            else
+                parts.Add("00");
+        }
+        return string.Join(".", parts);
+    }
+
+    /// <summary>
+    /// Finds all SQL scripts in the !SQL folder that are newer than the DB version
+    /// and up to (inclusive) the code version, ordered by version ascending.
+    /// </summary>
+    private List<(string FileName, string Version, int VersionInt)> GetPendingScripts()
+    {
+        var sqlDir = Path.Combine(AppContext.BaseDirectory, "!SQL");
+        if (!Directory.Exists(sqlDir))
+            return new();
+
+        var dbVersionInt = ConvertVersionToInteger(DatabaseVersion);
+        var codeVersionInt = ConvertVersionToInteger(CurrentCodeVersion);
+
+        var scripts = new List<(string FileName, string Version, int VersionInt)>();
+
+        foreach (var file in Directory.GetFiles(sqlDir, "*.sql").OrderBy(f => f))
+        {
+            var name = Path.GetFileNameWithoutExtension(file);
+            // Parse version from filename like "01.00.00" or "02.00.00"
+            var versionInt = ConvertVersionToInteger(name);
+            if (versionInt > dbVersionInt && versionInt <= codeVersionInt)
+            {
+                scripts.Add((file, name, versionInt));
+            }
+        }
+
+        return scripts.OrderBy(s => s.VersionInt).ToList();
+    }
+
     private async Task Authenticate()
     {
         ErrorMessage = string.Empty;
@@ -62,39 +110,103 @@
         Stage = "running";
         Logs.Clear();
 
-        Logs.Add($"[{DateTime.Now.ToShortTimeString()}] Starting database backup...");
-        StateHasChanged();
-        await Task.Delay(1000);
+        try
+        {
+            var pendingScripts = GetPendingScripts();
 
-        Logs.Add($"[{DateTime.Now.ToShortTimeString()}] Backup completed successfully.");
-        StateHasChanged();
-        await Task.Delay(500);
+            if (pendingScripts.Count == 0)
+            {
+                Logs.Add($"[{DateTime.Now.ToShortTimeString()}] No pending migration scripts found.");
+                StateHasChanged();
+                await Task.Delay(500);
 
-        Logs.Add($"[{DateTime.Now.ToShortTimeString()}] Applying migration scripts...");
-        StateHasChanged();
-        await Task.Delay(1500);
+                Logs.Add($"[{DateTime.Now.ToShortTimeString()}] Updating schema version to {CurrentCodeVersion}...");
+                StateHasChanged();
+                await SettingsService.SetAsync("SchemaVersion", CurrentCodeVersion, "Database schema version tracking");
 
-        Logs.Add($"[{DateTime.Now.ToShortTimeString()}] Running script: 01.00.00.sql");
-        StateHasChanged();
-        await Task.Delay(1000);
+                Logs.Add($"[{DateTime.Now.ToShortTimeString()}] ✓ Schema version updated.");
+                StateHasChanged();
+                Stage = "complete";
+                return;
+            }
 
-        Logs.Add($"[{DateTime.Now.ToShortTimeString()}] Database schema updated.");
-        StateHasChanged();
-        await Task.Delay(500);
+            Logs.Add($"[{DateTime.Now.ToShortTimeString()}] Found {pendingScripts.Count} migration script(s) to apply.");
+            Logs.Add($"[{DateTime.Now.ToShortTimeString()}] Database version: {DatabaseVersion} → Code version: {CurrentCodeVersion}");
+            StateHasChanged();
+            await Task.Delay(300);
 
-        Logs.Add($"[{DateTime.Now.ToShortTimeString()}] Updating version table...");
-        StateHasChanged();
-        await Task.Delay(500);
+            var connStr = Configuration.GetConnectionString("blazororchestratordb");
+            if (string.IsNullOrEmpty(connStr))
+            {
+                Logs.Add($"[{DateTime.Now.ToShortTimeString()}] ✗ No database connection string found.");
+                StateHasChanged();
+                return;
+            }
 
-        Logs.Add($"[{DateTime.Now.ToShortTimeString()}] ✓ Upgrade completed successfully!");
-        StateHasChanged();
+            await using var connection = new SqlConnection(connStr);
+            await connection.OpenAsync();
 
-        Stage = "complete";
+            foreach (var (fileName, version, versionInt) in pendingScripts)
+            {
+                Logs.Add($"[{DateTime.Now.ToShortTimeString()}] Running script: {Path.GetFileName(fileName)}");
+                StateHasChanged();
+
+                var script = await File.ReadAllTextAsync(fileName);
+                var batches = SplitSqlBatches(script).ToList();
+
+                int batchIndex = 0;
+                foreach (var batch in batches)
+                {
+                    if (string.IsNullOrWhiteSpace(batch)) continue;
+                    batchIndex++;
+                    await connection.ExecuteAsync(batch);
+                }
+
+                Logs.Add($"[{DateTime.Now.ToShortTimeString()}] ✓ Script {Path.GetFileName(fileName)} applied ({batchIndex} batches).");
+                StateHasChanged();
+
+                // Update schema version after each script succeeds
+                await SettingsService.SetAsync("SchemaVersion", version, "Database schema version tracking");
+            }
+
+            // Final schema version update to match code version
+            await SettingsService.SetAsync("SchemaVersion", CurrentCodeVersion, "Database schema version tracking");
+
+            Logs.Add($"[{DateTime.Now.ToShortTimeString()}] Schema version updated to {CurrentCodeVersion}.");
+            Logs.Add($"[{DateTime.Now.ToShortTimeString()}] ✓ Upgrade completed successfully!");
+            StateHasChanged();
+
+            Stage = "complete";
+        }
+        catch (Exception ex)
+        {
+            Logs.Add($"[{DateTime.Now.ToShortTimeString()}] ✗ Error: {ex.Message}");
+            StateHasChanged();
+        }
+    }
+
+    private static IEnumerable<string> SplitSqlBatches(string script)
+    {
+        var lines = script.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+        var sb = new System.Text.StringBuilder();
+        foreach (var line in lines)
+        {
+            if (line.Trim().Equals("GO", StringComparison.OrdinalIgnoreCase))
+            {
+                yield return sb.ToString();
+                sb.Clear();
+            }
+            else
+            {
+                sb.AppendLine(line);
+            }
+        }
+        if (sb.Length > 0)
+            yield return sb.ToString();
     }
 
     private async Task SkipUpgrade()
     {
-        // Allow user to continue when local version is ahead (dev/pre-release scenario)
         if (OnUpgradeComplete.HasDelegate)
         {
             await OnUpgradeComplete.InvokeAsync();
@@ -116,9 +228,9 @@
         <RadzenCard Style="width: 450px;" Class="rz-shadow-5">
             <div class="text-center rz-mb-4">
                 <RadzenIcon Icon="system_update" IconColor="@Colors.Warning" Style="font-size: 3rem;" />
-                <RadzenText TextStyle="TextStyle.H5" Class="rz-mt-2">System Upgrade Required</RadzenText>
+                <RadzenText TextStyle="TextStyle.H5" Class="rz-mt-2">Database Upgrade Required</RadzenText>
                 <RadzenText TextStyle="TextStyle.Body2" Class="rz-color-base-500">
-                    Your Version: <strong>@CurrentCodeVersion</strong> | Latest Version: <strong>@LatestGitHubVersion</strong>
+                    Database Version: <strong>@DatabaseVersion</strong> | Code Version: <strong>@CurrentCodeVersion</strong>
                 </RadzenText>
             </div>
 
@@ -146,33 +258,21 @@ else if (Stage == "check")
         <RadzenCard Style="width: 600px;" Class="rz-shadow-5">
             <div class="d-flex justify-content-between align-items-center rz-mb-5 rz-px-4">
                 <div class="text-center">
-                    <RadzenText TextStyle="TextStyle.Overline">YOUR VERSION</RadzenText>
-                    <RadzenText TextStyle="TextStyle.H4">@CurrentCodeVersion</RadzenText>
+                    <RadzenText TextStyle="TextStyle.Overline">DATABASE VERSION</RadzenText>
+                    <RadzenText TextStyle="TextStyle.H4">@DatabaseVersion</RadzenText>
                 </div>
                 <RadzenIcon Icon="arrow_forward" Style="font-size: 2rem; color: #ccc;" />
                 <div class="text-center">
-                    <RadzenText TextStyle="TextStyle.Overline">LATEST VERSION</RadzenText>
-                    <RadzenText TextStyle="TextStyle.H4" Class="rz-color-primary">@LatestGitHubVersion</RadzenText>
+                    <RadzenText TextStyle="TextStyle.Overline">CODE VERSION</RadzenText>
+                    <RadzenText TextStyle="TextStyle.H4" Class="rz-color-primary">@CurrentCodeVersion</RadzenText>
                 </div>
             </div>
 
-            @if (IsDowngrade)
-            {
-                <RadzenAlert AlertStyle="AlertStyle.Warning" ShowIcon="true" Variant="Variant.Flat" Shade="Shade.Lighter">
-                    <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.Div">Version Mismatch</RadzenText>
-                    Your local code version is higher than the latest published version on GitHub.
-                    This may happen if you are running a development or pre-release version.
-                </RadzenAlert>
-                <RadzenButton Click="SkipUpgrade" Text="Continue Anyway" ButtonStyle="ButtonStyle.Warning" Style="width: 100%; margin-top: 1rem;" Icon="skip_next" />
-            }
-            else
-            {
-                <RadzenAlert AlertStyle="AlertStyle.Info" ShowIcon="true" Variant="Variant.Flat" Shade="Shade.Lighter">
-                    <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.Div">Upgrade Available</RadzenText>
-                    Migration scripts are ready to be applied. A backup will be created before upgrading.
-                </RadzenAlert>
-                <RadzenButton Click="RunScripts" Text="Apply Upgrade" ButtonStyle="ButtonStyle.Primary" Style="width: 100%; margin-top: 1rem;" Icon="upgrade" />
-            }
+            <RadzenAlert AlertStyle="AlertStyle.Info" ShowIcon="true" Variant="Variant.Flat" Shade="Shade.Lighter">
+                <RadzenText TextStyle="TextStyle.Subtitle2" TagName="TagName.Div">Database Migration Required</RadzenText>
+                Your code version is ahead of the database schema. Migration scripts will be applied to bring the database up to date.
+            </RadzenAlert>
+            <RadzenButton Click="RunScripts" Text="Apply Upgrade" ButtonStyle="ButtonStyle.Primary" Style="width: 100%; margin-top: 1rem;" Icon="upgrade" />
         </RadzenCard>
     </div>
 }
@@ -204,7 +304,7 @@ else if (Stage == "complete")
                 <RadzenIcon Icon="check_circle" IconColor="@Colors.Success" Style="font-size: 4rem;" />
                 <RadzenText TextStyle="TextStyle.H5" Class="rz-mt-2">Upgrade Complete!</RadzenText>
                 <RadzenText TextStyle="TextStyle.Body2" Class="rz-color-base-500">
-                    Application has been upgraded to version <strong>@LatestGitHubVersion</strong>
+                    Database has been upgraded to version <strong>@CurrentCodeVersion</strong>
                 </RadzenText>
             </div>
 
@@ -213,9 +313,8 @@ else if (Stage == "complete")
                     <strong>Summary:</strong>
                 </RadzenText>
                 <ul style="margin-bottom: 0; padding-left: 20px;">
-                    <li>Database backup created successfully</li>
                     <li>Migration scripts applied</li>
-                    <li>Version updated to @LatestGitHubVersion</li>
+                    <li>Schema version updated to @CurrentCodeVersion</li>
                 </ul>
             </RadzenCard>
 

--- a/src/BlazorOrchestrator.Web/Data/DatabaseInitializer.cs
+++ b/src/BlazorOrchestrator.Web/Data/DatabaseInitializer.cs
@@ -1,12 +1,13 @@
 using System.Data;
 using Microsoft.Data.SqlClient;
 using Dapper;
+using BlazorDataOrchestrator.Core.Services;
 
 namespace BlazorOrchestrator.Web.Data;
 
 public static class DatabaseInitializer
 {
-    public static async Task EnsureDatabaseAsync(IConfiguration configuration, ILogger logger, Action<string>? onProgress = null)
+    public static async Task EnsureDatabaseAsync(IConfiguration configuration, ILogger logger, Action<string>? onProgress = null, SettingsService? settingsService = null, string? currentVersion = null)
     {
         var connStr = configuration.GetConnectionString("blazororchestratordb");
         if (string.IsNullOrWhiteSpace(connStr))
@@ -100,6 +101,23 @@ public static class DatabaseInitializer
             var successMsg = "Database initialization script executed successfully.";
             logger.LogInformation(successMsg);
             onProgress?.Invoke($"✅ {successMsg}");
+
+            // Write initial SchemaVersion to Azure Table Storage
+            if (settingsService != null && !string.IsNullOrEmpty(currentVersion))
+            {
+                try
+                {
+                    onProgress?.Invoke($"📝 Setting SchemaVersion to {currentVersion}...");
+                    await settingsService.SetAsync("SchemaVersion", currentVersion, "Database schema version tracking");
+                    onProgress?.Invoke($"✅ SchemaVersion set to {currentVersion}.");
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "Failed to set SchemaVersion in Azure Table Storage.");
+                    onProgress?.Invoke($"⚠️ Could not set SchemaVersion: {ex.Message}");
+                }
+            }
+
             onProgress?.Invoke("🎉 Database setup complete!");
         }
         catch (Exception ex)


### PR DESCRIPTION
This pull request implements a major refactor of the upgrade and version-checking logic for the application, following the new plan outlined in `UpgradeWizardRefactorPlan.md`. The changes ensure that database migrations are only triggered when the local code version is ahead of the database version, and that GitHub version checks are non-blocking and advisory (via a dismissible dashboard banner). The upgrade workflow is now script-driven, executing only the necessary migration scripts based on version gaps.

The most important changes are:

**Upgrade and Version Checking Logic**

* Replaced the old upgrade trigger logic with a new method (`IsCodeAheadOfDatabaseAsync`) that compares the compiled code version to the database schema version, only showing the upgrade wizard when the code version is newer. The GitHub version is now checked in the background and only displays a dismissible informational banner if newer code is available. (`src/BlazorOrchestrator.Web/Components/Pages/Home.razor`) [[1]](diffhunk://#diff-6d39b3a7fe7e0fd562c85e3f15925f955e5e2fe3d57ceafee31238e79f4be3bbR261-R263) [[2]](diffhunk://#diff-6d39b3a7fe7e0fd562c85e3f15925f955e5e2fe3d57ceafee31238e79f4be3bbL350-R372) [[3]](diffhunk://#diff-6d39b3a7fe7e0fd562c85e3f15925f955e5e2fe3d57ceafee31238e79f4be3bbL364-R384) [[4]](diffhunk://#diff-6d39b3a7fe7e0fd562c85e3f15925f955e5e2fe3d57ceafee31238e79f4be3bbL428-R501)

* Added persistent tracking of the database schema version using the `SettingsService` and ensured the version is written to the database on install. (`src/BlazorOrchestrator.Web/Components/Pages/InstallUpgrade/InstallWizard.razor`)

**UI Improvements**

* Added a non-blocking, dismissible update banner to the dashboard, which appears only if a newer GitHub version is detected. The banner can be dismissed for the session and does not block access to the dashboard. (`src/BlazorOrchestrator.Web/Components/Pages/Home.razor`) [[1]](diffhunk://#diff-6d39b3a7fe7e0fd562c85e3f15925f955e5e2fe3d57ceafee31238e79f4be3bbR79-R92) [[2]](diffhunk://#diff-6d39b3a7fe7e0fd562c85e3f15925f955e5e2fe3d57ceafee31238e79f4be3bbR261-R263)

**Upgrade Workflow Refactor**

* Refactored the `UpgradeWorkflow` component to accept the database version instead of the GitHub version, and implemented logic to discover and execute only the necessary SQL migration scripts based on the version gap between the database and the code. (`src/BlazorOrchestrator.Web/Components/Pages/InstallUpgrade/UpgradeWorkflow.razor`) [[1]](diffhunk://#diff-e4f61ea4bc0b7928273d52cf81c8f044b84564badc3e39d25ce6b2a27bd2b449R3-L23) [[2]](diffhunk://#diff-e4f61ea4bc0b7928273d52cf81c8f044b84564badc3e39d25ce6b2a27bd2b449R47-R92)

**Documentation**

* Added a comprehensive refactor plan in `docs/UpgradeWizardRefactorPlan.md`, detailing the new versioning architecture, user flows, and implementation steps.

These changes make the upgrade process safer, more intuitive, and less disruptive for users, while providing clear guidance on when code or database updates are required.